### PR TITLE
Workflow: Add workflow for docs upload to S3

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,31 @@
+name: Sync docs to S3
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-sync.yml"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.DOCS_SYNC_AWS_ROLE_ARN }}
+          aws-region: eu-central-1
+
+      - name: Sync docs folder to S3
+        run: aws s3 sync ./docs s3://nuclia-docs-aws-global-stage-1/dotnet-sdk


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate syncing documentation files to an S3 bucket whenever changes are made to the `docs` folder or the workflow file itself. This ensures that the latest documentation is always available in the designated S3 location.

**Documentation automation:**

* Added `.github/workflows/docs-sync.yml` to define a workflow that triggers on pushes to `master` affecting the `docs` folder or the workflow file, as well as on manual dispatch. The workflow checks out the repository, configures AWS credentials using OIDC, and syncs the `docs` folder to the `nuclia-docs-aws-global-stage-1/dotnet-sdk` S3 bucket.